### PR TITLE
Update LauncherMgr.cs

### DIFF
--- a/UnityProject/Assets/Launcher/Scripts/LauncherMgr.cs
+++ b/UnityProject/Assets/Launcher/Scripts/LauncherMgr.cs
@@ -63,6 +63,7 @@ namespace Launcher
                     {
                         ui.transform.SetParent(_uiRoot.transform);
                         ui.transform.localScale = Vector3.one;
+                        ui.transform.localRotation = Quaternion.identity;
                         ui.transform.localPosition = Vector3.zero;
                         RectTransform rect = ui.GetComponent<RectTransform>();
                         rect.sizeDelta = Vector2.zero;


### PR DESCRIPTION
// 解决秘之Bug,如果你旋转了UI相机会导致 界面也跟着旋转

我找了半天 这个 ，没有找到有什么地方设置了旋转。
![image](https://github.com/user-attachments/assets/18d35582-7be1-45b6-bf54-7fcb4d6cad96)

如果UI相机旋转，这个也会整体跟着旋转，导致整体 不旋转。但是局部会旋转一部分抵消世界坐标系下的旋转。

如果有更好的解决方案，那会更好。